### PR TITLE
Hide the control layer by using Up arrow key when focusing on player buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ function App() {
         mediaIndex={0}
         onLikePress={handleLike}
         playsinline={true}
+        hideControlsOnArrowUp={true}
       />
     </>
   );

--- a/src/lib/TVPlayerTypes.ts
+++ b/src/lib/TVPlayerTypes.ts
@@ -37,4 +37,5 @@ export interface TVPlayerProps extends ReactPlayerProps {
   subTitle?: string | null;
   title?: string | null;
   withTopCover?: boolean;
+  hideControlsOnArrowUp?: boolean;
 }

--- a/src/lib/TVPlayerUI/TVPlayerUI.tsx
+++ b/src/lib/TVPlayerUI/TVPlayerUI.tsx
@@ -235,6 +235,12 @@ export const TVPlayerUI: React.FC<TVPlayerProps> = (props) => {
                 }
                 key={index}
                 disabled={button.disabled || buttonMap[button.action].disabled}
+                handleArrowPress={(dir) => {
+                  if (dir === "up") {
+                    actions.setActivity(false);
+                  }
+                  return true;
+                }}
               >
                 <FontAwesomeIcon
                   icon={

--- a/src/lib/TVPlayerUI/TVPlayerUI.tsx
+++ b/src/lib/TVPlayerUI/TVPlayerUI.tsx
@@ -61,6 +61,7 @@ export const TVPlayerUI: React.FC<TVPlayerProps> = (props) => {
     withTopCover,
     customButtons,
     disableFullscreen,
+    hideControlsOnArrowUp,
   } = props;
   const { focusKey, ref } = useFocusable();
 
@@ -236,7 +237,7 @@ export const TVPlayerUI: React.FC<TVPlayerProps> = (props) => {
                 key={index}
                 disabled={button.disabled || buttonMap[button.action].disabled}
                 handleArrowPress={(dir) => {
-                  if (dir === "up") {
+                  if (hideControlsOnArrowUp && dir === "up") {
                     actions.setActivity(false);
                   }
                   return true;


### PR DESCRIPTION
I have try to use this project on TV.
It's really cool player for TV.
After using it on TV, I have 1 small thing need to improve about UX on TV.

Instead of waiting four seconds to hide the control layer, I think we should add option to let users to do so proactively.
And I have contribute it by using Up arrow key when focusing on the player buttons.
Could you please review it?
Thank you!